### PR TITLE
Remove unused global variable to fix compilation with GCC 10

### DIFF
--- a/src/CryptSym.h
+++ b/src/CryptSym.h
@@ -81,7 +81,7 @@ union tpmCryptKeySchedule_t {
 #else
     uint32_t            alignment;
 #endif
-} tpmCryptKeySchedule;
+};
 /* Each block cipher within a library is expected to conform to the same calling conventions with
    three parameters (keySchedule, in, and out) in the same order. That means that all algorithms
    would use the same order of the same parameters. The code is written assuming the (keySchedule,


### PR DESCRIPTION
GCC [defaults to `-fno-common`](https://gcc.gnu.org/gcc-10/porting_to.html#common), resulting in a compilation error:
```
CryptSym.h:84: multiple definition of `tpmCryptKeySchedule'
```
Since the global variable is not used anywhere, it can be removed.