### PR TITLE
TpmProfile.h: increase NV_MEMORY_SIZE to account for RSA 3072 keys

### DIFF
--- a/src/TpmProfile.h
+++ b/src/TpmProfile.h
@@ -201,7 +201,7 @@
 #define MAX_CAP_BUFFER                  1024
 #endif
 #ifndef NV_MEMORY_SIZE
-#define NV_MEMORY_SIZE                  16384
+#define NV_MEMORY_SIZE                  32768
 #endif
 #ifndef MIN_COUNTER_INDICES
 #define MIN_COUNTER_INDICES             8


### PR DESCRIPTION
Version 1628 [enabled RSA 3072](https://github.com/kgoldman/ibmswtpm2/commit/eda7f4d5bcd2936bec7126ce896f9e05b66191be#diff-4882cf1ec816e76c1f5fa8e8928df6c9L394), thus increasing the object size, without increasing the NV memory. As a result, only three objects can be persisted (`TPM_PT_HR_PERSISTENT_AVAIL`), which is a very small number (less than many commercially available TPMs). Increase the memory size to 2^15=32768 to account for the algorithm change, which allows to persist up to 10 objects.