### PR TITLE
TcpServerPosix: Fix use of uninitialized value.

### DIFF
--- a/src/LibSupport.h
+++ b/src/LibSupport.h
@@ -75,7 +75,8 @@
 #       define RADIX_BITS                      64
 #   elif defined(__i386__) || defined(__i386) || defined(i386)		\
     || defined(_WIN32) || defined(_M_IX86)				\
-    || defined(_M_ARM) || defined(__arm__) || defined(__thumb__)
+    || defined(_M_ARM) || defined(__arm__) || defined(__thumb__)	\
+    || defined(__powerpc__)
 #       define RADIX_BITS                      32
 #   else
 #       error Unable to determine RADIX_BITS from compiler environment

--- a/src/NVDynamic.c
+++ b/src/NVDynamic.c
@@ -122,7 +122,7 @@ NvNextByType(
 	    if(HandleGetType(nvHandle) == type)
 		break;
 	}
-    if(handle != NULL)
+    if(addr && (handle != NULL))
 	*handle = nvHandle;
     return addr;
 }

--- a/src/TcpServerPosix.c
+++ b/src/TcpServerPosix.c
@@ -278,7 +278,8 @@ PlatformServer(
 		      {
 			  UINT32 actHandle;
 			  ok = ReadUINT32(s, &actHandle);
-			  WriteUINT32(s, _rpc__ACT_GetSignaled(actHandle));
+			  if(ok)
+			      WriteUINT32(s, _rpc__ACT_GetSignaled(actHandle));
 			  break;
 		      }
 		  default:


### PR DESCRIPTION
ReadUINT32 does not modify the output when it fails. Do not use the
output in that case.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>