### PR TITLE
Add support for OpenSSL 3.2.x

### DIFF
--- a/src/TpmToOsslMath.h
+++ b/src/TpmToOsslMath.h
@@ -76,10 +76,10 @@
  * As of release 3.0.0, OPENSSL_VERSION_NUMBER is a combination of the
  * major (M), minor (NN) and patch (PP) version into a single integer 0xMNN00PP0L
  */
-#if OPENSSL_VERSION_NUMBER > 0x30100ff0L
+#if OPENSSL_VERSION_NUMBER > 0x30200ff0L
 // Check the bignum_st definition in crypto/bn/bn_lcl.h or crypto/bn/bn_local.h and either update
 // the version check or provide the new definition for this version.
-// Currently safe for all 3.1.x
+// Currently safe for all 3.2.x
 #   error Untested OpenSSL version
 #elif OPENSSL_VERSION_NUMBER >= 0x10100000L
 // from crypto/bn/bn_lcl.h


### PR DESCRIPTION
OpenSSL 3.2.0 has been released so it's time to add support for this version to ibmswtpm2.

Same as in #9, I have verified that the definition of `bignum_st` in `crypto/bn/bn_local.h` has not changed, so it should be safe to use the new version. But maybe it's not sufficient and further tests/changes are required.

 