### PR TITLE
src/BnToOsslMath.h: fix build with openssl 3.4.x

### DIFF
--- a/src/BnToOsslMath.h
+++ b/src/BnToOsslMath.h
@@ -77,7 +77,7 @@
 #include <openssl/ec.h>
 #include <openssl/bn.h>
 
-#if OPENSSL_VERSION_NUMBER >= 0x30300ff0L
+#if OPENSSL_VERSION_NUMBER >= 0x30400ff0L
 // Check the bignum_st definition against the one below and either update the
 // version check or provide the new definition for this version.
 #  error Untested OpenSSL version


### PR DESCRIPTION
Openssl 3.4.x is out:
https://github.com/openssl/openssl/blob/openssl-3.4.0/NEWS.md#openssl-34

So bump the max supported version number similar to how it was done by commit 89a4cb9cf8 "src/BnToOsslMath.h: fix build with openssl 3.3.x" to fix build failures with 3.4.x:

    In file included from BnValues.h:327,
                     from Global.h:80,
                     from Tpm.h:78,
                     from AuditCommands.c:62:
    TpmToOsslMath.h:83:5: error: #error Untested OpenSSL version
       83 | #   error Untested OpenSSL version
          |     ^~~~~

Fixes:
- http://autobuild.buildroot.net/results/be6c679b821183b4385c74471e26d9ad7d3d8967