### PR TITLE
tpm: Update to OpenSSL 3.6

### DIFF
--- a/src/BnToOsslMath.h
+++ b/src/BnToOsslMath.h
@@ -77,7 +77,7 @@
 #include <openssl/ec.h>
 #include <openssl/bn.h>
 
-#if OPENSSL_VERSION_NUMBER >= 0x30500ff0L
+#if OPENSSL_VERSION_NUMBER >= 0x30600ff0L
 // Check the bignum_st definition against the one below and either update the
 // version check or provide the new definition for this version.
 #  error Untested OpenSSL version


### PR DESCRIPTION
OpenSSL 3.6 is now available, accept it as a supported version.